### PR TITLE
Set PolySharp reference PrivateAssets to all

### DIFF
--- a/Disarm/Disarm.csproj
+++ b/Disarm/Disarm.csproj
@@ -32,7 +32,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.13.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+		<PackageReference Include="PolySharp" Version="1.13.1" Condition="'$(TargetFramework)' == 'netstandard2.0'">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
         <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>


### PR DESCRIPTION
Prevents Disarm from adding some types to projects that use it and potentially causing type collisions (as mentioned on Discord)